### PR TITLE
Refactor ocean shader and exposure for Godot 4.4

### DIFF
--- a/native/src/scripts/objects/camera.rs
+++ b/native/src/scripts/objects/camera.rs
@@ -23,7 +23,7 @@ struct Camera {
 impl Camera {
     const MID_DAY_EXPOSURE: f32 = 10.0;
     const DAWN_EXPOSURE: f32 = 30.0;
-    const NIGHT_EXPOSURE: f32 = 1000.0;
+    const NIGHT_EXPOSURE: f32 = 400.0;
 
     pub fn _ready(&mut self) {
         Signal::from_object_signal(&**self.solar_setup, "sky_brightness")

--- a/project.godot
+++ b/project.godot
@@ -165,3 +165,42 @@ environment/volumetric_fog/volume_depth=100
 anti_aliasing/quality/use_taa=true
 occlusion_culling/use_occlusion_culling=true
 environment/defaults/default_environment="res://resources/Environments/default_env.tres"
+
+[shader_globals]
+
+ocean_noise_scale={
+"type": "float",
+"value": 0.002
+}
+ocean_wave_dir={
+"type": "float",
+"value": 0.124
+}
+ocean_speed={
+"type": "float",
+"value": 0.03
+}
+ocean_noise={
+"type": "sampler2D",
+"value": "res://resources/Textures/ocean/ocean_bump.tres"
+}
+ocean_wave2_dir={
+"type": "float",
+"value": 0.569
+}
+ocean_wave_ratio={
+"type": "float",
+"value": 0.5
+}
+ocean_normal_map={
+"type": "sampler2D",
+"value": "res://resources/Textures/ocean/ocean_normal.tres"
+}
+ocean_water_color={
+"type": "color",
+"value": Color(0.192157, 0.219608, 0.243137, 1)
+}
+ocean_deep_water_color={
+"type": "color",
+"value": Color(0, 0, 0.113725, 1)
+}

--- a/resources/Materials/ocean_backdrop.tres
+++ b/resources/Materials/ocean_backdrop.tres
@@ -1,37 +1,9 @@
-[gd_resource type="ShaderMaterial" load_steps=5 format=3 uid="uid://7h8w8gb1xjbk"]
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://7h8w8gb1xjbk"]
 
 [ext_resource type="Shader" uid="uid://b7iel7s3r8acu" path="res://resources/Shaders/ocean_shader.gdshader" id="1_tvxot"]
-
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_52xgy"]
-noise_type = 4
-fractal_type = 2
-fractal_gain = 0.3
-fractal_weighted_strength = 0.3
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_06ugh"]
-width = 1024
-height = 1024
-seamless = true
-noise = SubResource("FastNoiseLite_52xgy")
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_l65p1"]
-width = 1024
-height = 1024
-seamless = true
-as_normal_map = true
-noise = SubResource("FastNoiseLite_52xgy")
 
 [resource]
 render_priority = 0
 shader = ExtResource("1_tvxot")
-shader_parameter/noise_scale = 0.02
-shader_parameter/Wave_Dir = 0.124
-shader_parameter/speed = 0.1
-shader_parameter/Noise = SubResource("NoiseTexture2D_06ugh")
-shader_parameter/Wave2_Dir = 0.569
-shader_parameter/Wave_Ratio = 0.5
-shader_parameter/wave_height = 0.0
-shader_parameter/Normal_Map = SubResource("NoiseTexture2D_l65p1")
 shader_parameter/Normal_Depth = 1.0
-shader_parameter/water_color = Color(0, 0, 0.113725, 1)
-shader_parameter/water_deep_color = Color(0, 0, 0.113725, 1)
+shader_parameter/wave_height = 0.0

--- a/resources/Materials/ocean_material.tres
+++ b/resources/Materials/ocean_material.tres
@@ -1,37 +1,9 @@
-[gd_resource type="ShaderMaterial" load_steps=5 format=3 uid="uid://bmp5rvu5slnnt"]
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://bmp5rvu5slnnt"]
 
 [ext_resource type="Shader" uid="uid://b7iel7s3r8acu" path="res://resources/Shaders/ocean_shader.gdshader" id="1_1ltun"]
-
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_52xgy"]
-noise_type = 4
-fractal_type = 2
-fractal_gain = 0.3
-fractal_weighted_strength = 0.3
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_06ugh"]
-width = 1024
-height = 1024
-seamless = true
-noise = SubResource("FastNoiseLite_52xgy")
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_l65p1"]
-width = 1024
-height = 1024
-seamless = true
-as_normal_map = true
-noise = SubResource("FastNoiseLite_52xgy")
 
 [resource]
 render_priority = 0
 shader = ExtResource("1_1ltun")
-shader_parameter/noise_scale = 0.02
-shader_parameter/Wave_Dir = 0.124
-shader_parameter/speed = 0.1
-shader_parameter/Noise = SubResource("NoiseTexture2D_06ugh")
-shader_parameter/Wave2_Dir = 0.569
-shader_parameter/Wave_Ratio = 0.5
-shader_parameter/wave_height = 5.0
-shader_parameter/Normal_Map = SubResource("NoiseTexture2D_l65p1")
 shader_parameter/Normal_Depth = 1.0
-shader_parameter/water_color = Color(0, 0, 0.113725, 1)
-shader_parameter/water_deep_color = Color(0, 0, 0.113725, 1)
+shader_parameter/wave_height = 5.0

--- a/resources/Shaders/ocean_shader.gdshader
+++ b/resources/Shaders/ocean_shader.gdshader
@@ -1,26 +1,33 @@
 // Inspired by: https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-19-generic-refraction-simulation
 
 shader_type spatial;
+render_mode cull_back, specular_schlick_ggx;
 
 // Varyings
 varying vec2 vary_world_uv;
 varying vec2 vary_world_uv2;
 
-uniform float noise_scale : hint_range(0, 1) = 0.01999999955297;
-uniform float Wave_Dir : hint_range(0, 1);
-uniform float speed : hint_range(0, 0.5, 0.05000000074506) = 0.10000000149012;
-uniform sampler2D Noise : hint_default_black;
-uniform float Wave2_Dir : hint_range(0, 1);
-uniform float Wave_Ratio : hint_range(0, 1) = 0.5;
-uniform float wave_height;
-uniform sampler2D Normal_Map : hint_normal, repeat_enable;
+global uniform float ocean_noise_scale : hint_range(0, 1);
+global uniform float ocean_wave_dir : hint_range(0, 1);
+global uniform float ocean_speed : hint_range(0, 0.5, 0.001);
+global uniform sampler2D ocean_noise : hint_default_black, repeat_enable;
+global uniform float ocean_wave2_dir : hint_range(0, 1);
+global uniform float ocean_wave_ratio : hint_range(0, 1);
+global uniform sampler2D ocean_normal_map : hint_normal, repeat_enable;
+global uniform vec4 ocean_water_color: source_color;
+global uniform vec4 ocean_deep_water_color: source_color;
 uniform float Normal_Depth;
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
 uniform sampler2D depth_texture : hint_depth_texture, repeat_disable;
-uniform vec3 water_color: source_color = vec3(0, 0.15, 0.115);
-uniform vec3 water_deep_color: source_color = vec3(0.0, 0.15, 0.115);
+uniform float wave_height;
 
 const float WAVE_CONST = 6.28300;
+
+// Perform color correction for Spatial shader:
+// https://github.com/godotengine/godot/issues/70927#issuecomment-1371464030
+vec4 correct_color(vec4 color) {
+	return pow(color, vec4(2.2));
+}
 
 vec2 vec2ComposeFunc(float _vec2_length, float _vec2_angl_rad){
 	return vec2(cos(_vec2_angl_rad), sin(_vec2_angl_rad)) * _vec2_length;
@@ -42,22 +49,31 @@ float fresnel(float n_dot_l, float fresnel_bias, float fresnel_pow) {
 	return max(fresnel_bias + (1.0 - fresnel_bias) * pow(facing, fresnel_pow), 0.0);
 }
 
+vec3 sample_wave_noise(sampler2D map) {
+	vec3 wave_normal = texture(map, vary_world_uv).rgb;
+	vec3 wave2_normal = texture(map, vary_world_uv2).rgb;
+
+	vec3 mixed_waves = mix(wave_normal, wave2_normal, ocean_wave_ratio);
+
+	return mixed_waves;
+}
+
 void vertex() {
 	vec3 word_vertex = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	float scaled_time = speed * TIME;
-	vec2 world_uv = vec2(word_vertex.x, word_vertex.z) * vec2(noise_scale);
+	float scaled_time = ocean_speed * 0.5 * TIME;
+	vec2 world_uv = vec2(word_vertex.x, word_vertex.z) * vec2(ocean_noise_scale);
 
-	vec3 wave_uv_offset = vec3(vec2ComposeFunc(1.00000, WAVE_CONST * Wave_Dir), 0.0);
+	vec3 wave_uv_offset = vec3(vec2ComposeFunc(1.00000, WAVE_CONST * ocean_wave_dir), 0.0);
 	vec2 wave_uv_offset_t = vec2(wave_uv_offset.xy) * vec2(scaled_time);
 
-	float wave_noise = texture(Noise, world_uv + wave_uv_offset_t).r;
+	vary_world_uv = world_uv + wave_uv_offset_t;
 
-	vec3 wave2_uv_offset = vec3(vec2ComposeFunc(1.00000, WAVE_CONST * Wave2_Dir), 0.0);
+	vec3 wave2_uv_offset = vec3(vec2ComposeFunc(1.00000, WAVE_CONST * ocean_wave2_dir), 0.0);
 	vec2 wave2_uv_offset_t = vec2(wave2_uv_offset.xy) * vec2(scaled_time);
 
-	float wave2_noise = texture(Noise, world_uv + wave2_uv_offset_t).r;
+	vary_world_uv2 = world_uv + wave2_uv_offset_t;
 
-	float mixed_waves = mix(wave_noise, wave2_noise, Wave_Ratio);
+	float mixed_waves = sample_wave_noise(ocean_noise).r;
 	float mixed_waves_inv = mixed_waves - 1.00000;
 
 	float vertex_y_offset = mixed_waves_inv * wave_height;
@@ -68,14 +84,10 @@ void vertex() {
 
 // Output
 	VERTEX = transformed_vertex;
-
-	vary_world_uv = world_uv + wave_uv_offset_t;
-	vary_world_uv2 = world_uv + wave2_uv_offset_t;
 }
 
 void fragment() {
-	vec2 world_uv = mix(vary_world_uv, vary_world_uv2, Wave_Ratio);
-	vec3 normal = texture(Normal_Map, world_uv).rgb;
+	vec3 normal = sample_wave_noise(ocean_normal_map);
 
 	vec3 refraction_offset = (2.0 * normal.xyz - 1.0) * vec3(0.075, 0.075, 1.0);
 
@@ -90,17 +102,17 @@ void fragment() {
 	vec4 refraction_b = texture(screen_texture, SCREEN_UV.xy);
 	vec4 refraction_value = refraction_b * depth_mask + refraction_a * (1.0 - depth_mask);
 
-	float dist_scale = clamp(10.0 / depth(SCREEN_UV, INV_PROJECTION_MATRIX), 0.0, 1.0);
+	float dist_scale = clamp(6.0 / depth(SCREEN_UV, INV_PROJECTION_MATRIX), 0.0, 1.0);
 
-	vec3 water_deep_albedo = (refraction_value.xyz * dist_scale + (1.0 - dist_scale) * water_deep_color);
+	vec4 water_deep_albedo = (refraction_value * dist_scale + (1.0 - dist_scale) * correct_color(ocean_deep_water_color));
 
 	// Lerp between water color and deep water color
-  	vec3 water_albedo = (water_color * facing + water_deep_albedo * (1.0 - facing));
+  	vec4 water_albedo = (correct_color(ocean_water_color) * facing + water_deep_albedo * (1.0 - facing));
 
-	ROUGHNESS = 1.0 - max(fresnel, 1.0);
+	ROUGHNESS = 0.2;
 	NORMAL_MAP = normal;
 	NORMAL_MAP_DEPTH = Normal_Depth;
 
 	// Refraction output
-	ALBEDO = water_albedo;
+	ALBEDO = water_albedo.rgb;
 }

--- a/resources/TestScenes/ocean.tscn
+++ b/resources/TestScenes/ocean.tscn
@@ -42,7 +42,7 @@ height = 200.0
 [node name="ocean" type="Node3D"]
 
 [node name="Plane" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, -3.48787e-16, 3.48787e-16, 3.48787e-16, 1, -3.48787e-16, -3.48787e-16, 3.48787e-16, 1, 2.08165e-12, 38, 2.08165e-12)
+transform = Transform3D(1, -3.48787e-16, 3.48787e-16, 3.48787e-16, 1, -3.48787e-16, -3.48787e-16, 3.48787e-16, 1, 0, 32.505, 0)
 mesh = SubResource("1")
 surface_material_override/0 = ExtResource("1_4qrcu")
 

--- a/resources/Textures/ocean/ocean_bump.tres
+++ b/resources/Textures/ocean/ocean_bump.tres
@@ -1,0 +1,9 @@
+[gd_resource type="NoiseTexture2D" load_steps=2 format=3 uid="uid://dlcr6r41spof7"]
+
+[ext_resource type="FastNoiseLite" uid="uid://rd36gy30hcxi" path="res://resources/Textures/ocean/ocean_noise.tres" id="1_sx12a"]
+
+[resource]
+width = 2048
+height = 2048
+seamless = true
+noise = ExtResource("1_sx12a")

--- a/resources/Textures/ocean/ocean_noise.tres
+++ b/resources/Textures/ocean/ocean_noise.tres
@@ -1,0 +1,8 @@
+[gd_resource type="FastNoiseLite" format=3 uid="uid://rd36gy30hcxi"]
+
+[resource]
+noise_type = 4
+fractal_type = 2
+fractal_lacunarity = 3.0
+fractal_gain = 0.4
+fractal_weighted_strength = 1.0

--- a/resources/Textures/ocean/ocean_normal.tres
+++ b/resources/Textures/ocean/ocean_normal.tres
@@ -1,0 +1,11 @@
+[gd_resource type="NoiseTexture2D" load_steps=2 format=3 uid="uid://ddkn772jpvtht"]
+
+[ext_resource type="FastNoiseLite" uid="uid://rd36gy30hcxi" path="res://resources/Textures/ocean/ocean_noise.tres" id="1_vakfg"]
+
+[resource]
+width = 2048
+height = 2048
+seamless = true
+as_normal_map = true
+bump_strength = 32.0
+noise = ExtResource("1_vakfg")


### PR DESCRIPTION
Night exposure level is too high in Godot 4.4 compared to 4.3. The ocean is also reflecting a lot of light during nighttime, which prompted some refactoring of the shader.