### PR TITLE
Water impacts can cause errors

### DIFF
--- a/native/src/scripts/objects/debugger_3_d.rs
+++ b/native/src/scripts/objects/debugger_3_d.rs
@@ -6,14 +6,14 @@ use itertools::Itertools;
 
 #[derive(GodotScript, Debug)]
 #[script(base = Node3D)]
-struct Debugger3D {
+pub struct Debugger3D {
     #[export]
     pub title: GString,
 
     #[export]
     pub text_view: OnEditor<Gd<RichTextLabel>>,
 
-    pub debug_data: Dictionary,
+    debug_data: Dictionary,
 }
 
 #[godot_script_impl]
@@ -28,5 +28,9 @@ impl Debugger3D {
             .join("\n");
 
         self.text_view.set_text(&format!("{}\n\n{}", title, values));
+    }
+
+    pub fn debug_data(&self) -> Dictionary {
+        self.debug_data.clone()
     }
 }

--- a/project.godot
+++ b/project.godot
@@ -128,6 +128,11 @@ strafe_right={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":68,"location":0,"echo":false,"script":null)
 ]
 }
+debug_snapshot={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":true,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":83,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [network]
 
@@ -137,6 +142,7 @@ limits/debugger_stdout/max_chars_per_second=1000000
 
 common/physics_ticks_per_second=120
 3d/physics_engine="Jolt Physics"
+jolt_physics_3d/simulation/areas_detect_static_bodies=true
 3d/default_gravity=9.81
 common/physics_interpolation=true
 

--- a/resources/Objects/Helis/Upgrades/canon.tscn
+++ b/resources/Objects/Helis/Upgrades/canon.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://c0pat4v54oe86"]
+[gd_scene load_steps=23 format=3 uid="uid://c0pat4v54oe86"]
 
 [ext_resource type="PackedScene" uid="uid://daf3wyyha2hm" path="res://resources/Meshes/Helis/upgrades/cannon.gltf" id="1_54ycj"]
 [ext_resource type="Script" uid="uid://dvqexwe8r1gw7" path="res://native/src/scripts/objects/canon_upgrade.rs" id="2_1jnub"]
@@ -14,18 +14,12 @@
 [ext_resource type="AnimationLibrary" uid="uid://ccdoql0ui30qd" path="res://resources/Animations/canon_water_jet.tres" id="10_u6k6a"]
 [ext_resource type="AnimationNodeStateMachine" uid="uid://bhxg4j3d3uxr0" path="res://resources/Animations/canon_water_jet_animation_states.tres" id="11_sjwuo"]
 
-[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_tggho"]
-points = PackedVector3Array(0.0634894, 0.28541, 1.47195, -0.1009, 0.219458, 1.10271, -0.1009, 0.412842, 1.10271, 0.0935621, 0.4137, 1.1008, -0.1009, 0.412842, 1.43675, 0.0934082, 0.2184, 1.10108, -0.1009, 0.219458, 1.43675, 0.0935621, 0.4137, 1.43846, 0.0934082, 0.2184, 1.43821, -0.0138567, 0.459466, 1.3559, -0.0332037, 0.208029, 1.47195, 0.0248164, 0.459466, 1.16252, -0.0332037, 0.324124, 1.47195, 0.0441425, 0.208029, 1.47195, -0.0138567, 0.459466, 1.16252, 0.0248164, 0.459466, 1.3559, -0.0525298, 0.304755, 1.47195, 0.0441425, 0.324124, 1.47195, -0.0525298, 0.227374, 1.47195, 0.0634894, 0.246719, 1.47195)
-
-[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_yhox5"]
-points = PackedVector3Array(-0.0560845, 0.225026, 1.4461, 0.0635008, 0.285379, 2.32289, 0.0635008, 0.246727, 2.32289, 0.0670385, 0.286558, 1.4461, -0.0332018, 0.324066, 2.32289, -0.03556, 0.327603, 1.4461, -0.0332018, 0.208041, 2.32289, 0.0441557, 0.208041, 1.47204, 0.046514, 0.327603, 1.4461, -0.0525468, 0.304722, 2.32289, 0.0441557, 0.324066, 2.32289, 0.0441557, 0.208041, 2.32289, -0.0560845, 0.30708, 1.4461, -0.0525468, 0.227384, 2.32289, -0.0332018, 0.208041, 1.47204, 0.0670385, 0.245549, 1.4461)
-
 [sub_resource type="QuadMesh" id="QuadMesh_wqt7j"]
 material = ExtResource("3_lyjqx")
 size = Vector2(0.7, 0.7)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_aet65"]
-size = Vector3(15.1061, 26.5005, 75.1869)
+size = Vector3(15.1061, 26.5005, 74.4762)
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_e4rg2"]
 radius = 0.4
@@ -45,6 +39,9 @@ radius = 7.0
 [sub_resource type="ViewportTexture" id="ViewportTexture_0mey1"]
 viewport_path = NodePath("WaterJetDebugger/SubViewport")
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_p6un2"]
+size = Vector3(0.101135, 0.0903931, 0.882935)
+
 [node name="Canon" node_paths=PackedStringArray("water_jet") instance=ExtResource("1_54ycj")]
 transform = Transform3D(-1, 3.48787e-16, -8.74228e-08, 3.48787e-16, 1, -3.48787e-16, 8.74228e-08, -3.48787e-16, -1, 0, 0, 0)
 script = ExtResource("2_1jnub")
@@ -53,14 +50,6 @@ water_jet = NodePath("WaterJet")
 
 [node name="Maxis-3d2-mesh-143" parent="." index="0"]
 transform = Transform3D(1, -4.02216e-24, 0, -4.02216e-24, 1, 0, 0, 0, 1, 0, 0, 0)
-
-[node name="CollisionShape3D_B" type="CollisionShape3D" parent="Maxis-3d2-mesh-143" index="0"]
-transform = Transform3D(1, -4.02216e-24, 0, -4.02216e-24, 1, 0, 0, 0, 1, 0, 0, 0)
-shape = SubResource("ConvexPolygonShape3D_tggho")
-
-[node name="CollisionShape3D_A" type="CollisionShape3D" parent="Maxis-3d2-mesh-143" index="1"]
-transform = Transform3D(1, -4.02216e-24, 0, -4.02216e-24, 1, 0, 0, 0, 1, 0, 0, 0)
-shape = SubResource("ConvexPolygonShape3D_yhox5")
 
 [node name="WaterJet" type="GPUParticles3D" parent="." index="1" node_paths=PackedStringArray("impact_area", "decal", "debugger")]
 transform = Transform3D(-1, 3.48787e-16, -8.74228e-08, 3.48787e-16, 1, -3.48787e-16, 8.74228e-08, -3.48787e-16, -1, -5.06016e-15, 0.266152, 2.15765)
@@ -91,10 +80,9 @@ script = ExtResource("9_v48py")
 
 [node name="ParticleImpactArea" type="Area3D" parent="WaterJet" index="1"]
 transform = Transform3D(1, -1.47268e-30, 0, -1.47268e-30, 1, 0, 0, 0, 1, 0, 0, 0)
-visible = false
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="WaterJet/ParticleImpactArea" index="0"]
-transform = Transform3D(1, 0, -9.67226e-10, 0, 1, 0, -9.67226e-10, 0, 1, -0.0208936, -12.7502, -37.0935)
+transform = Transform3D(1, -1.47268e-30, -9.67219e-10, -1.49828e-30, 1, 0, -9.67219e-10, 0, 1, -0.0208936, -12.7502, -37.4488)
 shape = SubResource("BoxShape3D_aet65")
 
 [node name="ParticleImpactCastA" type="ShapeCast3D" parent="WaterJet" index="2"]
@@ -140,8 +128,8 @@ target_position = Vector3(2.08165e-12, -8, -18)
 collision_mask = 3
 
 [node name="ParticleCollision" type="GPUParticlesCollisionHeightField3D" parent="WaterJet" index="8"]
-transform = Transform3D(1, 0, 1.19942e-09, 0, 1, 0, 1.19942e-09, 0, 1, 0.425537, -22.2146, -55.7903)
-size = Vector3(219.237, 52.5883, 115.03)
+transform = Transform3D(1, -1.47268e-30, 1.19942e-09, -1.44093e-30, 1, 0, 1.19942e-09, 0, 1, 0.425537, -22.2146, -56.759)
+size = Vector3(219.237, 52.5883, 113.093)
 
 [node name="AudioSource" type="AudioStreamPlayer3D" parent="WaterJet" index="9"]
 transform = Transform3D(1, 1.68276e-30, 0, -1.47268e-30, 1, -4.73317e-30, 0, 0, 1, 0.121209, -0.140246, -2.91244)
@@ -151,7 +139,7 @@ max_db = 6.0
 
 [node name="AudioPlayer" type="AnimationPlayer" parent="WaterJet" index="10"]
 libraries = {
-"": ExtResource("10_u6k6a")
+&"": ExtResource("10_u6k6a")
 }
 
 [node name="AnimationTree" type="AnimationTree" parent="WaterJet" index="11"]
@@ -176,3 +164,7 @@ transparent_bg = true
 size = Vector2i(300, 500)
 
 [node name="WaterJetDebugControl" parent="WaterJetDebugger/SubViewport" index="0" instance=ExtResource("10_51x2k")]
+
+[node name="CanonShape" type="CollisionShape3D" parent="." index="3"]
+transform = Transform3D(1, -4.02216e-24, 0, -4.02216e-24, 1, 0, 0, 0, 1, -0.000404409, 0.264907, 1.88774)
+shape = SubResource("BoxShape3D_p6un2")

--- a/resources/Objects/Helis/schweizer_300.tscn
+++ b/resources/Objects/Helis/schweizer_300.tscn
@@ -40,15 +40,15 @@ ao_on_uv2 = true
 subsurf_scatter_strength = 0.3
 
 [sub_resource type="CapsuleShape3D" id="22"]
-radius = 0.63507
-height = 1.27014
+radius = 0.65
+height = 2.1
 
 [sub_resource type="BoxShape3D" id="17"]
 size = Vector3(1.31, 0.42, 2.502)
 
 [sub_resource type="CapsuleShape3D" id="18"]
 radius = 0.15
-height = 4.0
+height = 4.45619
 
 [sub_resource type="CylinderShape3D" id="19"]
 height = 0.08
@@ -99,7 +99,7 @@ surface_material_override/0 = ExtResource("6_y4h4o")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0980453, 1.52714, 4.24386)
 
 [node name="BodyShape" type="CollisionShape3D" parent="." index="6"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00923181, 1.07085, -0.367273)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0.00923181, 1.07085, -0.601074)
 shape = SubResource("22")
 
 [node name="StandShape" type="CollisionShape3D" parent="." index="7"]
@@ -107,7 +107,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, -0.65716)
 shape = SubResource("17")
 
 [node name="TailShape" type="CollisionShape3D" parent="." index="8"]
-transform = Transform3D(1, 0, 0, 0, -0.0842326, 0.996446, 0, -0.996446, -0.0842326, 0, 1.39094, 2.65674)
+transform = Transform3D(1, 0, 0, 0, -0.0842326, 0.996446, 0, -0.996446, -0.0842326, 0, 1.38301, 2.56298)
 shape = SubResource("18")
 
 [node name="RotorShape" type="CollisionShape3D" parent="." index="9"]

--- a/src/Objects/Helicopters/Helicopter.gd
+++ b/src/Objects/Helicopters/Helicopter.gd
@@ -250,6 +250,7 @@ func mount_upgrades():
 
 		object.set_meta("scene_instance_id", scene.get_instance_id())
 
+		# prevent duplicates
 		for child in self.child_upgrade_mount.get_children():
 			if child.get_meta("scene_instance_id") == scene.get_instance_id():
 				duplicate = true
@@ -259,7 +260,23 @@ func mount_upgrades():
 			return
 
 		self.child_upgrade_mount.add_child(object, true)
-		object.owner = self.child_upgrade_mount
+		object.owner = self.get_tree().current_scene
+		
+		# attach collision shapes
+		for child in object.get_children():
+			if not child is CollisionShape3D:
+				continue
+				
+			var coll_child: CollisionShape3D = child
+			# get the local tranform relative to our body node
+			var transform := self.global_transform.inverse() * coll_child.global_transform
+			
+			var owner := self.create_shape_owner(child)
+			self.shape_owner_set_transform(owner, transform)
+			self.shape_owner_set_disabled(owner, coll_child.disabled)
+			self.shape_owner_add_shape(owner, coll_child.shape)
+
+
 		self.upgrade_action_dispatch[upgrade.action] = object
 
 

--- a/src/Objects/World/World.gd
+++ b/src/Objects/World/World.gd
@@ -105,3 +105,11 @@ func _insert_spawn_point(building_coords: Array[int], building_size: int, altitu
 
 	spawn_host.translate(location)
 	self.add_child(spawn_host)
+
+
+func _input(event: InputEvent) -> void:
+	if not OS.has_feature("debug"):
+		return
+
+	if event.is_action_pressed("debug_snapshot", false, true):
+		self._create_snapshot()


### PR DESCRIPTION
Some raycasts were going in the wrong direction and causing the intersection normal to be ZERO. This normal then caused errors when trying to align the decal to it.

Helicopter upgrade collision shapes are also not being taken into account because they are not direct children of the `RigidBody`. This can be fixed by manually registering them. 