### PR TITLE
Terrain Occlusion

### DIFF
--- a/native/src/terrain_builder.rs
+++ b/native/src/terrain_builder.rs
@@ -154,6 +154,15 @@ pub struct TerrainBuilder {
 
 #[godot_api]
 impl TerrainBuilder {
+    const GROUND_SURFACE: &str = "ground";
+
+    const WATER_SURFACE: &str = "water";
+
+    #[func]
+    fn ground_surface() -> StringName {
+        Self::GROUND_SURFACE.into()
+    }
+
     #[func]
     fn new(
         tilelist: Dictionary,
@@ -763,6 +772,13 @@ fn generate_chunk_mesh(context: &WorkerThreadContext, chunk: ChunkSurfaces) -> T
         let new_index = mesh.get_surface_count();
 
         mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &surface_arrays);
+
+        let surface_name = match surface_type {
+            TileSurfaceType::Ground => TerrainBuilder::GROUND_SURFACE,
+            TileSurfaceType::Water => TerrainBuilder::WATER_SURFACE,
+        };
+
+        mesh.surface_set_name(new_index, surface_name);
 
         let surface_material_variant = context.materials.get(surface_type.to_string());
 

--- a/src/Objects/Terrain/Terrain.gd
+++ b/src/Objects/Terrain/Terrain.gd
@@ -61,14 +61,35 @@ func build_async():
 		
 		translation.y = 0
 		
+		var occluder := create_terrain_occluder(chunk.mesh())
 		var mesh_instance := MeshInstance3D.new()
 
 		mesh_instance.mesh = chunk.mesh()
 		mesh_instance.cast_shadow = MeshInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
 		mesh_instance.create_trimesh_collision()
-
-		self.add_child(mesh_instance, true)
+		mesh_instance.add_child(occluder, false)
+		
+		self.add_child(mesh_instance, false)
+		
 		mesh_instance.owner = get_tree().current_scene
+		occluder.owner = get_tree().current_scene
+		
 		mesh_instance.translate(translation)
 	
 	prints("generated terain:", self.get_child_count(), "nodes generated")
+
+
+func create_terrain_occluder(mesh: ArrayMesh) -> OccluderInstance3D:
+	var surface_index := mesh.surface_find_by_name(TerrainBuilder.ground_surface())
+	var terrain_surface := mesh.surface_get_arrays(surface_index)
+	var vertecies: PackedVector3Array = terrain_surface[Mesh.ArrayType.ARRAY_VERTEX]
+	var indices: PackedInt32Array = terrain_surface[Mesh.ArrayType.ARRAY_INDEX]
+	
+	var occluder := OccluderInstance3D.new()
+	var occluder_mesh := ArrayOccluder3D.new()
+	
+	occluder_mesh.vertices = vertecies
+	occluder_mesh.indices = indices
+	occluder.occluder = occluder_mesh
+	
+	return occluder


### PR DESCRIPTION
Add occluders for terrain so objects that are hidden behind a terrain chunk can be culled. The impact of this isn't very great, though.