### PR TITLE
Smaller chunks render faster

### DIFF
--- a/native/src/terrain_builder.rs
+++ b/native/src/terrain_builder.rs
@@ -174,7 +174,7 @@ impl TerrainBuilder {
             city_size: 0,
             tile_height: 8,
             sea_level: 0,
-            chunk_size: 32,
+            chunk_size: 8,
             rotation,
             tilelist,
             materials,

--- a/project.godot
+++ b/project.godot
@@ -37,7 +37,7 @@ display_server/driver.linuxbsd="wayland"
 window/size/viewport_width.release=1920
 window/size/viewport_height.release=1080
 window/size/mode.release=3
-window/vsync/use_vsync=true
+window/vsync/use_vsync=false
 
 [editor]
 
@@ -154,6 +154,7 @@ textures/vram_compression/import_etc2_astc=true
 lights_and_shadows/use_physical_light_units=true
 lights_and_shadows/directional_shadow/size=8192
 lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
+lights_and_shadows/directional_shadow/16_bits=false
 lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 global_illumination/voxel_gi/quality=1
 environment/ssao/half_size=false

--- a/resources/Environments/WorldEnv.tres
+++ b/resources/Environments/WorldEnv.tres
@@ -15,6 +15,7 @@ ssr_enabled = true
 ssr_max_steps = 128
 ssr_fade_in = 0.05
 ssr_fade_out = 1.5
+ssr_depth_tolerance = 0.51
 ssao_ao_channel_affect = 1.0
 sdfgi_enabled = true
 sdfgi_cascades = 5


### PR DESCRIPTION
Reducing the chunk size improves the render performance of the terrain. On an M1 with 1280x720, we go from ~40 FPS to ~70 FPS.