### PR TITLE
Only set window size when windowed

### DIFF
--- a/src/HUD/HUDController.gd
+++ b/src/HUD/HUDController.gd
@@ -11,9 +11,15 @@ func _ready():
 	world.loading_scale.connect(self._on_loading_scale)
 	world.loading_progress.connect(self._on_loading_progress)
 	
-	var scale := DisplayServer.screen_get_scale(DisplayServer.SCREEN_OF_MAIN_WINDOW)
 	var window := self.get_window()
-	
+
+	if window.mode == Window.Mode.MODE_WINDOWED:
+		self.set_window_scale(window)
+
+
+func set_window_scale(window: Window):
+	var scale := DisplayServer.screen_get_scale(DisplayServer.SCREEN_OF_MAIN_WINDOW)
+
 	window.size *= scale
 	window.position -= Vector2i(self.get_window().size / scale / 2)
 


### PR DESCRIPTION
Applying the system scaling factor to the window size only makes sense when the game is started in windowed mode.