### PR TITLE
Splash Screen background color

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="Sim Chopper"
 run/main_scene="res://resources/main.tscn"
 config/features=PackedStringArray("4.4")
+boot_splash/bg_color=Color(0, 0, 0, 1)
 
 [debug]
 


### PR DESCRIPTION
A splash screen with a fully black background looks much better, especially in fullscreen mode.