### PR TITLE
Upgrade to gdext 0.4 #115

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -178,9 +178,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "gdextension-api"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec0a03c8f9c91e3d8eb7ca56dea81c7248c03826dd3f545f33cd22ef275d4d1"
+checksum = "e25d88dabe9fdb2e064cb545312178ec4025eefb62d9a3bbce1769088e2c381d"
 
 [[package]]
 name = "getrandom"
@@ -219,9 +219,9 @@ checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "godot"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab462a365a4b8bcfcdaf93afe767a189a183edfb1d1e697bde9fb26c3f9bfbe9"
+checksum = "1a9b5fac6f08345fe81f840353b433c3e8cd07a105cb23ea080251173c149625"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -229,24 +229,24 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597469df0a890b2c7f102b094942e6b184e7ee573adf6ed35fad0421ee86b8fa"
+checksum = "96920225203f1ccee3d1fd4513402a31a4d6567e437367c704682f7eee43eda3"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e48bf49cf5d6ef0b64b2a58be980e4854f57e75b822889d639f96c3c098a5ec"
+checksum = "bdb34522bce7b863ef4dbf154be53392f23e32747877b4c7e759a0ec43876b3f"
 
 [[package]]
 name = "godot-codegen"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282e80108e93950e66ed3a40f7dcb6f61978ecb0dd2d19ad7028799d6a5537cb"
+checksum = "396303aaca6c212cf85442e78afcf28844b06b564bbc23f37c40ec57885f4395"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593ce360312bdec4c45994402dc624c43c3dd8741c8e6391958626dcf635b40"
+checksum = "be623c121c8cd24a0e173771d73a0cbf8180840abd4389f4c78e698018d729ae"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce5ae6a7ae29a753f2f0af3d2a2f3194fa482d9900fc167f35a0738fe7d54d2"
+checksum = "10a8358c83761a174b33640944e72ec2fabf0274f516520b68ab8a140ac25d97"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0f3ebf0fe09733267c4631ae0af2d6b1008b322d032832ddcfb4dfc54607ad"
+checksum = "96066983ab510b0f89ea2f5b3e1dc47eaf9126f0f9e595da6cba4e7bf49a84dd"
 dependencies = [
  "godot-bindings",
  "litrs",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "godot-rust-script"
 version = "0.1.0"
-source = "git+https://github.com/titannano/godot-rust-script?rev=d0a814cfbd8cefa843029bcdf97084307dbaf0d5#d0a814cfbd8cefa843029bcdf97084307dbaf0d5"
+source = "git+https://github.com/titannano/godot-rust-script?rev=05d23bc481ec3cd02007d27d0edf952f7af2658e#05d23bc481ec3cd02007d27d0edf952f7af2658e"
 dependencies = [
  "const-str",
  "godot",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "godot-rust-script-derive"
 version = "0.1.0"
-source = "git+https://github.com/titannano/godot-rust-script?rev=d0a814cfbd8cefa843029bcdf97084307dbaf0d5#d0a814cfbd8cefa843029bcdf97084307dbaf0d5"
+source = "git+https://github.com/titannano/godot-rust-script?rev=05d23bc481ec3cd02007d27d0edf952f7af2658e#05d23bc481ec3cd02007d27d0edf952f7af2658e"
 dependencies = [
  "darling",
  "itertools",
@@ -393,9 +393,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 dependencies = [
  "proc-macro2",
 ]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { version = "0.3.2", features = ["experimental-threads", "api-4-4", "register-docs"] }
-godot-rust-script = { git = "https://github.com/titannano/godot-rust-script", rev = "d0a814cfbd8cefa843029bcdf97084307dbaf0d5" }
+godot = { version = "0.4.2", features = ["experimental-threads", "api-4-4", "register-docs"] }
+godot-rust-script = { git = "https://github.com/titannano/godot-rust-script", rev = "05d23bc481ec3cd02007d27d0edf952f7af2658e" }
 lerp = "0.4.0"
 backtrace = "0.3.64"
 num = "0.4.0"

--- a/native/src/editor.rs
+++ b/native/src/editor.rs
@@ -16,7 +16,7 @@ use godot::classes::{
 };
 use godot::global::{self, godot_error, godot_print, PropertyHint};
 use godot::meta::{AsArg, FromGodot};
-use godot::obj::{Base, Gd, NewGd, OnReady, WithBaseField};
+use godot::obj::{Base, Gd, NewGd, OnReady, Singleton as _, WithBaseField};
 use godot::register::{godot_api, GodotClass};
 
 use building_imports::SetupBuildingImports;
@@ -25,7 +25,7 @@ use crate::engine_callable;
 use crate::util::variant_type_default_value;
 
 #[derive(GodotClass)]
-#[class(tool, base=EditorPlugin)]
+#[class(tool, base=EditorPlugin, internal)]
 struct EditorExtension {
     setup_building_imports: Gd<SetupBuildingImports>,
     gltf_importer: Gd<GltfImporter>,

--- a/native/src/editor/ao_baker.rs
+++ b/native/src/editor/ao_baker.rs
@@ -7,7 +7,7 @@ use godot::{
     builtin::{GString, PackedStringArray, VariantType},
     classes::{EditorInterface, ProjectSettings, RefCounted, SceneTree},
     global::PropertyHint,
-    obj::{Base, Gd},
+    obj::{Base, Gd, Singleton},
     prelude::{godot_api, GodotClass},
     task,
 };

--- a/native/src/editor/building_imports.rs
+++ b/native/src/editor/building_imports.rs
@@ -8,7 +8,7 @@ use godot::{
     },
     global::Error,
     meta::ToGodot,
-    obj::{Base, Gd, GodotClass, NewAlloc, NewGd, WithBaseField},
+    obj::{Base, Gd, GodotClass, NewAlloc, NewGd, Singleton as _, WithBaseField},
     register::{godot_api, GodotClass},
 };
 use pomsky_macro::pomsky;
@@ -116,7 +116,7 @@ impl SetupBuildingImports {
                     .get_directories()
                     .to_vec()
                     .into_iter()
-                    .map(|dir_name| format!("{dir_path}/{dir_name}").into())
+                    .map(|dir_name| GString::from(&format!("{dir_path}/{dir_name}")))
                     .collect(),
             );
             file_queue.append(
@@ -125,7 +125,7 @@ impl SetupBuildingImports {
                     .to_vec()
                     .into_iter()
                     .filter(|file_name| pattern.is_match(&file_name.to_string()))
-                    .map(|file_name| GString::from(format!("{dir_path}/{file_name}")))
+                    .map(|file_name| GString::from(&format!("{dir_path}/{file_name}")))
                     .collect(),
             );
         }
@@ -186,7 +186,7 @@ impl SetupBuildingImports {
 
         let scene = ResourceLoader::singleton()
             .load_ex(&config_file_name.replace(".import", ""))
-            .type_hint(&PackedScene::class_name().to_gstring())
+            .type_hint(&PackedScene::class_id().to_gstring())
             .done();
 
         let Some(scene) = scene else {
@@ -206,7 +206,7 @@ impl SetupBuildingImports {
 
         (0..scene_state.get_node_count())
             .filter(|index| {
-                scene_state.get_node_type(*index) == MeshInstance3D::class_name().to_string_name()
+                scene_state.get_node_type(*index) == MeshInstance3D::class_id().to_string_name()
             })
             .for_each(|index| {
                 let path = scene_state.get_node_path(index);

--- a/native/src/editor/ui/progress_dialog.rs
+++ b/native/src/editor/ui/progress_dialog.rs
@@ -6,7 +6,7 @@ use godot::classes::{
     window, Button, Control, EditorInterface, HBoxContainer, IPopupPanel, Label, MarginContainer,
     PopupPanel, ProgressBar, VBoxContainer,
 };
-use godot::obj::{Base, Gd, NewAlloc, WithBaseField};
+use godot::obj::{Base, Gd, NewAlloc, Singleton as _, WithBaseField};
 use godot::prelude::{godot_api, GodotClass};
 
 #[derive(GodotClass)]

--- a/native/src/objects/scene_object_registry.rs
+++ b/native/src/objects/scene_object_registry.rs
@@ -2,7 +2,7 @@
 
 use godot::classes::{PackedScene, ResourceLoader};
 use godot::global::godot_warn;
-use godot::obj::Gd;
+use godot::obj::{Gd, Singleton as _};
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 
 #[derive(TryFromPrimitive)]

--- a/native/src/road_navigation.rs
+++ b/native/src/road_navigation.rs
@@ -1,3 +1,4 @@
+use godot::obj::Singleton;
 use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;

--- a/native/src/scripts/objects/agents/car.rs
+++ b/native/src/scripts/objects/agents/car.rs
@@ -6,7 +6,7 @@ use godot::classes::{
     MeshInstance3D, PhysicsDirectBodyState3D, ProjectSettings, RayCast3D, RigidBody3D,
 };
 use godot::meta::ToGodot;
-use godot::obj::Gd;
+use godot::obj::{Gd, Singleton as _};
 use godot_rust_script::{godot_script_impl, GodotScript, OnEditor, RsRef};
 
 use crate::debug_3d;

--- a/native/src/scripts/objects/building.rs
+++ b/native/src/scripts/objects/building.rs
@@ -3,7 +3,7 @@ mod fire;
 use godot::builtin::Array;
 use godot::classes::{MeshInstance3D, Node};
 use godot::global::PropertyHint;
-use godot::meta::{FromGodot, GodotConvert, ToGodot};
+use godot::meta::{ByValue, FromGodot, GodotConvert, ToGodot};
 use godot::obj::{Gd, Inherits};
 use godot::prelude::ConvertError;
 use godot_rust_script::{godot_script_impl, GodotScript, GodotScriptExport};
@@ -39,7 +39,7 @@ impl FromGodot for BuildingEventFlags {
 }
 
 impl ToGodot for BuildingEventFlags {
-    type ToVia<'v> = Self::Via;
+    type Pass = ByValue;
 
     fn to_godot(&self) -> Self::Via {
         self.0

--- a/native/src/scripts/objects/building/fire.rs
+++ b/native/src/scripts/objects/building/fire.rs
@@ -1,7 +1,7 @@
 use godot::builtin::{math::ApproxEq, Transform3D, Vector3};
 use godot::classes::{MeshInstance3D, Node, Node3D, PackedScene, Time};
 use godot::meta::ToGodot;
-use godot::obj::{Gd, Inherits};
+use godot::obj::{Gd, Inherits, Singleton as _};
 use godot::tools::load;
 use godot_rust_script::{CastToScript, RsRef};
 use num::ToPrimitive;

--- a/native/src/scripts/objects/camera.rs
+++ b/native/src/scripts/objects/camera.rs
@@ -1,11 +1,9 @@
 use godot::builtin::math::{ApproxEq, FloatExt};
-use godot::builtin::Signal;
 use godot::classes::{Camera3D, CameraAttributesPhysical};
 use godot::obj::Gd;
 use godot_rust_script::{godot_script_impl, GodotScript, OnEditor, RsRef};
 use itertools::Itertools;
 
-use crate::script_callable;
 use crate::scripts::world::solar_setup::{ISolarSetup, SolarSetup};
 use crate::util::logger;
 
@@ -110,11 +108,6 @@ impl Camera {
             lux: Self::MAX_LIGHT_LUX,
         },
     ];
-
-    pub fn _ready(&mut self) {
-        Signal::from_object_signal(&**self.solar_setup, "sky_brightness")
-            .connect(&script_callable!(self, Self::_ready), 0);
-    }
 
     pub fn _process(&mut self, _delta: f64) {
         let Some(mut attributes): Option<Gd<CameraAttributesPhysical>> = self

--- a/native/src/scripts/world/buildings.rs
+++ b/native/src/scripts/world/buildings.rs
@@ -5,7 +5,7 @@ use derive_debug::Dbg;
 use godot::builtin::{Array, Dictionary};
 use godot::classes::{Marker3D, Node, Node3D, Time};
 use godot::meta::ToGodot;
-use godot::obj::{Gd, NewAlloc};
+use godot::obj::{Gd, NewAlloc, Singleton as _};
 use godot::task;
 use godot::task::TaskHandle;
 use godot_rust_script::{

--- a/native/src/scripts/world/solar_setup.rs
+++ b/native/src/scripts/world/solar_setup.rs
@@ -1,7 +1,7 @@
 use godot::builtin::math::FloatExt;
 use godot::builtin::Vector3;
 use godot::classes::{light_3d, DirectionalLight3D, Node3D, Performance, Time};
-use godot::obj::Gd;
+use godot::obj::{Gd, Singleton as _};
 use godot_rust_script::{godot_script_impl, GodotScript, OnEditor, ScriptSignal};
 use num::ToPrimitive;
 

--- a/native/src/util/async_support.rs
+++ b/native/src/util/async_support.rs
@@ -12,8 +12,6 @@ pub struct GodotFuture {
 
 #[godot_api]
 impl GodotFuture {
-    /// Returns an object which emits the completed signal once the asynchronus method has finished processing.
-
     /// Is emitted as soon as the async operation of the function has been completed.
     #[signal]
     fn completed(result: Variant);

--- a/native/src/util/logger.rs
+++ b/native/src/util/logger.rs
@@ -5,7 +5,7 @@ pub use crate::{debug, error, info, warn};
 macro_rules! log {
     ($level:ident, $out:ident, $($param:expr),+) => {
         {
-            let time = ::godot::classes::Time::singleton().get_ticks_msec();
+            let time = <::godot::classes::Time as ::godot::obj::Singleton>::singleton().get_ticks_msec();
             let minutes = time / 1000 / 60;
             let seconds = time / 1000 % 60;
             let milliseconds = time % 1000;

--- a/native/src/util/numbers.rs
+++ b/native/src/util/numbers.rs
@@ -1,5 +1,5 @@
 use godot::{
-    meta::{FromGodot, ToGodot},
+    meta::{ByValue, FromGodot, ToGodot},
     prelude::GodotConvert,
 };
 use godot_rust_script::{GetScriptProperty, GodotScriptExport, SetScriptProperty};
@@ -182,12 +182,9 @@ impl<const UPPER: u32, const LOWER: u32> FromGodot for LInt<LOWER, UPPER> {
 }
 
 impl<const UPPER: u32, const LOWER: u32> ToGodot for LInt<LOWER, UPPER> {
-    type ToVia<'v>
-        = Self::Via
-    where
-        Self: 'v;
+    type Pass = ByValue;
 
-    fn to_godot(&self) -> Self::ToVia<'_> {
+    fn to_godot(&self) -> Self::Via {
         self.into_u32()
     }
 }

--- a/src/native.gdextension
+++ b/src/native.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.1
-reloadable = false
+compatibility_minimum = 4.4
+reloadable = true
 
 [build]
 source = "res://native/"


### PR DESCRIPTION
Upgrade to gdext 0.4 to utilize the latest features and Godot 4.5 API support.