### PR TITLE
Default resolution for debug builds

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -31,15 +31,15 @@ shapes/road_navigation/display_vehicle_target=false
 
 [display]
 
-window/size/viewport_width=1280
-window/size/viewport_height=720
-window/size/always_on_top=true
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/size/mode=3
 window/stretch/mode="viewport"
-display_server/driver.linuxbsd="wayland"
-window/size/viewport_width.release=1920
-window/size/viewport_height.release=1080
-window/size/mode.release=3
-window/vsync/use_vsync=false
+window/vsync/vsync_mode=2
+window/size/viewport_height.editor=720
+window/size/viewport_width.editor=1280
+window/vsync/use_vsync=true
+window/size/mode.editor=0
 
 [editor]
 


### PR DESCRIPTION
Using fullscreen with 1080p resolution for exported debug builds and 720p when running inside the editor.