### PR TITLE
update gdext to 0.4.5

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -219,9 +219,9 @@ checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "godot"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9b5fac6f08345fe81f840353b433c3e8cd07a105cb23ea080251173c149625"
+checksum = "5599d03afd17a511e11d0bf9e06c88d4095a9120f10cf00a74f50b300f53413e"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -229,24 +229,24 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96920225203f1ccee3d1fd4513402a31a4d6567e437367c704682f7eee43eda3"
+checksum = "f38b6e65306c05e3c3f0131ee8dbf7394691e53268d72019007ec20687f2280f"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb34522bce7b863ef4dbf154be53392f23e32747877b4c7e759a0ec43876b3f"
+checksum = "738efef92fdcf1d92f0ed5a29c6f3cdce58e64029d08928c20e08771e1239c16"
 
 [[package]]
 name = "godot-codegen"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396303aaca6c212cf85442e78afcf28844b06b564bbc23f37c40ec57885f4395"
+checksum = "00b9a59f603f354c54d83fb74071209203d0ebe396b2419acc731c90ebf94680"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be623c121c8cd24a0e173771d73a0cbf8180840abd4389f4c78e698018d729ae"
+checksum = "989e80dfb58d2048ae0dca60bec32129dc1f96510f904b992ad170d84e950c33"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8358c83761a174b33640944e72ec2fabf0274f516520b68ab8a140ac25d97"
+checksum = "6237b26c52c5baa6566705a73cd8804ea4ef83a666540939dd5a4e068c242666"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96066983ab510b0f89ea2f5b3e1dc47eaf9126f0f9e595da6cba4e7bf49a84dd"
+checksum = "d696b67ba99ff7d75e07546b04c3a711651d2c9e5851c9225dea3b64f8bb5af6"
 dependencies = [
  "godot-bindings",
  "litrs",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { version = "0.4.2", features = ["experimental-threads", "api-4-5", "register-docs"] }
+godot = { version = "0.4.5", features = ["experimental-threads", "api-4-5", "register-docs"] }
 godot-rust-script = { git = "https://github.com/titannano/godot-rust-script", rev = "537f2c3ff52950440c6a5183fb2d13b07bea9901" }
 lerp = "0.4.0"
 backtrace = "0.3.64"

--- a/native/src/editor.rs
+++ b/native/src/editor.rs
@@ -8,7 +8,7 @@ use std::ops::DerefMut;
 
 use ao_baker::AoBaker;
 use gltf::GltfImporter;
-use godot::builtin::{Dictionary, GString, StringName, Variant, VariantType};
+use godot::builtin::{GString, StringName, VarDictionary, Variant, VariantType};
 use godot::classes::notify::NodeNotification;
 use godot::classes::{
     ConfigFile, EditorPlugin, EditorSettings, GDExtensionManager, GltfDocument, IEditorPlugin,
@@ -66,7 +66,7 @@ impl EditorExtension {
 
         project_settings.set_initial_value(&name.into(), &default_value);
 
-        let mut property = Dictionary::new();
+        let mut property = VarDictionary::new();
 
         property.set("name", name);
         property.set("type", ty);
@@ -227,7 +227,7 @@ trait EngineSettings {
     fn set_setting(&mut self, name: impl AsArg<GString>, value: &Variant);
     fn has_setting(&mut self, name: impl AsArg<GString>) -> bool;
     fn set_initial_value(&mut self, name: &StringName, value: &Variant);
-    fn add_property_info(&mut self, property_info: &Dictionary);
+    fn add_property_info(&mut self, property_info: &VarDictionary);
 }
 
 impl EngineSettings for Gd<ProjectSettings> {
@@ -244,7 +244,7 @@ impl EngineSettings for Gd<ProjectSettings> {
             .set_initial_value(&GString::from(name), value);
     }
 
-    fn add_property_info(&mut self, property_info: &Dictionary) {
+    fn add_property_info(&mut self, property_info: &VarDictionary) {
         self.deref_mut().add_property_info(property_info);
     }
 }
@@ -262,7 +262,7 @@ impl EngineSettings for Gd<EditorSettings> {
         self.deref_mut().set_initial_value(name, value, false);
     }
 
-    fn add_property_info(&mut self, property_info: &Dictionary) {
+    fn add_property_info(&mut self, property_info: &VarDictionary) {
         self.deref_mut().add_property_info(property_info);
     }
 }

--- a/native/src/editor/building_imports.rs
+++ b/native/src/editor/building_imports.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use godot::{
-    builtin::{Dictionary, GString, Vector2i},
+    builtin::{GString, VarDictionary, Vector2i},
     classes::{
         editor_file_dialog, ConfigFile, DirAccess, EditorFileDialog, EditorInterface, FileAccess,
         MeshInstance3D, Object, PackedScene, ResourceLoader,
@@ -163,9 +163,9 @@ impl SetupBuildingImports {
             return;
         }
 
-        let mut subresources: Dictionary = file
+        let mut subresources: VarDictionary = file
             .get_value_ex("params", "_subresources")
-            .default(&Dictionary::new().to_variant())
+            .default(&VarDictionary::new().to_variant())
             .done()
             .try_to()
             .inspect_err(|err| {
@@ -173,7 +173,7 @@ impl SetupBuildingImports {
             })
             .unwrap_or_default();
 
-        let mut nodes: Dictionary = subresources
+        let mut nodes: VarDictionary = subresources
             .get("nodes")
             .map(|value| value.try_to())
             .transpose()
@@ -210,7 +210,7 @@ impl SetupBuildingImports {
             })
             .for_each(|index| {
                 let path = scene_state.get_node_path(index);
-                let mut config: Dictionary = nodes
+                let mut config: VarDictionary = nodes
                     .get(path.clone())
                     .map(|value| value.try_to())
                     .transpose()

--- a/native/src/editor/gltf.rs
+++ b/native/src/editor/gltf.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use godot::builtin::{Array, Dictionary, GString, Variant, Vector3};
+use godot::builtin::{Array, GString, VarDictionary, Variant, Vector3};
 use godot::classes::decal::DecalTexture;
 use godot::classes::{
     base_material_3d, BaseMaterial3D, Decal, GltfNode, GltfState, IGltfDocumentExtension, Node,
@@ -93,14 +93,14 @@ fn fix_ao_uv2(state: &mut Gd<GltfState>) -> Result<(), global::Error> {
         let raw_material = raw_materials
             .iter_shared()
             .find(|mat| {
-                let Some(name) = mat.to::<Dictionary>().get("name") else {
+                let Some(name) = mat.to::<VarDictionary>().get("name") else {
                     logger::debug!("raw material doesn't have a name!");
                     return false;
                 };
 
                 material.get_name() == name.to()
             })
-            .map(|mat| mat.to::<Dictionary>());
+            .map(|mat| mat.to::<VarDictionary>());
 
         let Some(raw_material) = raw_material else {
             logger::error!("Unable to locate raw material in GLTF model!");
@@ -109,7 +109,7 @@ fn fix_ao_uv2(state: &mut Gd<GltfState>) -> Result<(), global::Error> {
 
         let tex_coord = raw_material
             .get("occlusionTexture")
-            .and_then(|occlusion_tex| occlusion_tex.to::<Dictionary>().get("texCoord"))
+            .and_then(|occlusion_tex| occlusion_tex.to::<VarDictionary>().get("texCoord"))
             .map_or(0.0, |tex_coord| tex_coord.to::<f64>());
 
         if tex_coord > 0.0 {
@@ -141,9 +141,9 @@ fn use_gd_node(
     let extras = gltf_raw_nodes
         .to::<Array<Variant>>()
         .at(index)
-        .to::<Dictionary>()
+        .to::<VarDictionary>()
         .get("extras")
-        .map(|var| var.to::<Dictionary>());
+        .map(|var| var.to::<VarDictionary>());
 
     let Some(extras) = extras else {
         return Ok(None);

--- a/native/src/road_navigation.rs
+++ b/native/src/road_navigation.rs
@@ -1,4 +1,3 @@
-use godot::obj::Singleton;
 use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -6,7 +5,7 @@ use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};
 use godot::builtin::math::ApproxEq;
-use godot::builtin::{Dictionary, Transform3D, Vector3};
+use godot::builtin::{Transform3D, VarDictionary, Vector3};
 use godot::classes::Node3D;
 use godot::global::snappedf;
 use godot::obj::{Gd, OnEditor};
@@ -456,7 +455,7 @@ impl RoadNavigationConfig {
     /// Insert a node into the road navigation graph.
     #[func]
     #[expect(clippy::needless_pass_by_value)]
-    pub fn insert_node(&mut self, building: Dictionary, scene_node: Gd<Node3D>) {
+    pub fn insert_node(&mut self, building: VarDictionary, scene_node: Gd<Node3D>) {
         let building = Building::try_from_dict(&building)
             .expect("building dictionary must be a vaild SC2K building.");
 

--- a/native/src/scripts/objects/debugger_3_d.rs
+++ b/native/src/scripts/objects/debugger_3_d.rs
@@ -1,4 +1,4 @@
-use godot::builtin::{Dictionary, GString};
+use godot::builtin::{GString, VarDictionary};
 use godot::classes::{Node3D, RichTextLabel};
 use godot::obj::Gd;
 use godot_rust_script::{godot_script_impl, GodotScript, OnEditor};
@@ -13,7 +13,7 @@ pub struct Debugger3D {
     #[export]
     pub text_view: OnEditor<Gd<RichTextLabel>>,
 
-    debug_data: Dictionary,
+    debug_data: VarDictionary,
 }
 
 #[godot_script_impl]
@@ -30,7 +30,7 @@ impl Debugger3D {
         self.text_view.set_text(&format!("{title}\n\n{values}"));
     }
 
-    pub fn debug_data(&self) -> Dictionary {
+    pub fn debug_data(&self) -> VarDictionary {
         self.debug_data.clone()
     }
 }

--- a/native/src/scripts/world/buildings.rs
+++ b/native/src/scripts/world/buildings.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, ops::Not};
 
 use anyhow::Context as _;
 use derive_debug::Dbg;
-use godot::builtin::{Array, Dictionary};
+use godot::builtin::{Array, VarDictionary};
 use godot::classes::{Marker3D, Node, Node3D, Time};
 use godot::meta::ToGodot;
 use godot::obj::{Gd, NewAlloc, Singleton as _};
@@ -59,7 +59,7 @@ impl Buildings {
         &self.world_constants
     }
 
-    pub fn build_async(&mut self, city: Dictionary, mut ctx: Context<Self>) -> Gd<GodotFuture> {
+    pub fn build_async(&mut self, city: VarDictionary, mut ctx: Context<Self>) -> Gd<GodotFuture> {
         let world_constants = self.world_constants().clone();
         let (resolve, godot_future) = async_support::godot_future();
 

--- a/native/src/terrain_builder.rs
+++ b/native/src/terrain_builder.rs
@@ -90,7 +90,7 @@ struct CoordinatorThreadContext {
     sea_level: u16,
     chunk_size: u32,
     rotation: TerrainRotation,
-    materials: Shared<Dictionary>,
+    materials: Shared<VarDictionary>,
     debug_render_invalid: bool,
     render_water: bool,
 }
@@ -118,7 +118,7 @@ struct WorkerThreadContext<'a> {
     sea_level: u16,
     rotation: &'a TerrainRotation,
     tilelist: &'a TileList,
-    materials: &'a Shared<Dictionary>,
+    materials: &'a Shared<VarDictionary>,
     debug_render_invalid: bool,
     render_water: bool,
 }
@@ -152,8 +152,8 @@ pub struct TerrainBuilder {
     sea_level: u16,
     chunk_size: u32,
     rotation: Gd<TerrainRotation>,
-    tilelist: Dictionary,
-    materials: Dictionary,
+    tilelist: VarDictionary,
+    materials: VarDictionary,
     debug_render_invalid: bool,
     render_water: bool,
     base: Base<RefCounted>,
@@ -172,9 +172,9 @@ impl TerrainBuilder {
 
     #[func]
     fn new(
-        tilelist: Dictionary,
+        tilelist: VarDictionary,
         rotation: Gd<TerrainRotation>,
-        materials: Dictionary,
+        materials: VarDictionary,
     ) -> Gd<TerrainBuilder> {
         Gd::from_init_fn(|base| TerrainBuilder {
             tile_size: 16,
@@ -224,7 +224,7 @@ impl TerrainBuilder {
     #[signal]
     fn progress(count: u32);
 
-    fn materials(&self) -> Shared<Dictionary> {
+    fn materials(&self) -> Shared<VarDictionary> {
         Shared(self.materials.clone())
     }
 
@@ -449,9 +449,9 @@ struct TerrainBuilderFactory;
 impl TerrainBuilderFactory {
     #[func]
     fn create(
-        tilelist: Dictionary,
+        tilelist: VarDictionary,
         rotation: Gd<TerrainRotation>,
-        materials: Dictionary,
+        materials: VarDictionary,
     ) -> Gd<TerrainBuilder> {
         TerrainBuilder::new(tilelist, rotation, materials)
     }

--- a/native/src/util.rs
+++ b/native/src/util.rs
@@ -4,11 +4,11 @@ mod numbers;
 
 #[cfg(debug_assertions)]
 use godot::builtin::{
-    Aabb, Callable, Color, Dictionary, NodePath, PackedByteArray, PackedColorArray,
-    PackedFloat32Array, PackedFloat64Array, PackedInt32Array, PackedInt64Array, PackedStringArray,
-    PackedVector2Array, PackedVector3Array, PackedVector4Array, Plane, Projection, Quaternion,
-    Rect2, Rect2i, Rid, Signal, StringName, Transform2D, Transform3D, Variant, VariantArray,
-    VariantType, Vector2, Vector2i, Vector3i, Vector4, Vector4i,
+    Aabb, Callable, Color, NodePath, PackedByteArray, PackedColorArray, PackedFloat32Array,
+    PackedFloat64Array, PackedInt32Array, PackedInt64Array, PackedStringArray, PackedVector2Array,
+    PackedVector3Array, PackedVector4Array, Plane, Projection, Quaternion, Rect2, Rect2i, Rid,
+    Signal, StringName, Transform2D, Transform3D, VarArray, VarDictionary, Variant, VariantType,
+    Vector2, Vector2i, Vector3i, Vector4, Vector4i,
 };
 use godot::builtin::{Basis, Vector3};
 #[cfg(debug_assertions)]
@@ -64,8 +64,8 @@ pub fn variant_type_default_value(ty: VariantType) -> Variant {
         VariantType::OBJECT => Variant::from(Object::new_alloc()),
         VariantType::CALLABLE => Variant::from(Callable::invalid()),
         VariantType::SIGNAL => Variant::from(Signal::invalid()),
-        VariantType::DICTIONARY => Variant::from(Dictionary::new()),
-        VariantType::ARRAY => Variant::from(VariantArray::new()),
+        VariantType::DICTIONARY => Variant::from(VarDictionary::new()),
+        VariantType::ARRAY => Variant::from(VarArray::new()),
         VariantType::PACKED_BYTE_ARRAY => Variant::from(PackedByteArray::new()),
         VariantType::PACKED_INT32_ARRAY => Variant::from(PackedInt32Array::new()),
         VariantType::PACKED_INT64_ARRAY => Variant::from(PackedInt64Array::new()),

--- a/native/src/world/city_data.rs
+++ b/native/src/world/city_data.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
-use godot::builtin::{Dictionary, VariantArray};
+use godot::builtin::{VarArray, VarDictionary};
 use godot::global::godot_warn;
 use godot::meta::error::ConvertError;
 use godot::meta::FromGodot;
@@ -13,7 +13,7 @@ mod terrain_slope;
 pub(crate) use terrain_slope::*;
 
 pub(crate) trait TryFromDictionary: Sized {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError>;
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -186,7 +186,7 @@ pub(crate) struct City {
 }
 
 impl TryFromDictionary for City {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError> {
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError> {
         Ok(Self {
             simulator_settings: get_dict_key(value, "simulator_settings")
                 .and_then(|value| SimulatorSettings::try_from_dict(&value))?,
@@ -210,7 +210,7 @@ pub(crate) struct Building {
 }
 
 impl TryFromDictionary for Building {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError> {
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError> {
         Ok(Self {
             size: get_dict_key(value, "size")?,
             name: get_dict_key(value, "name")?,
@@ -296,7 +296,7 @@ impl Tile {
 }
 
 impl TryFromDictionary for Tile {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError> {
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError> {
         Ok(Self {
             altitude: get_dict_key(value, "altitude")?,
             terrain: TileTerrainInfo::from(get_dict_key::<u32>(value, "terrain")?),
@@ -314,7 +314,7 @@ pub(crate) struct SimulatorSettings {
 }
 
 impl TryFromDictionary for SimulatorSettings {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError> {
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError> {
         Ok(Self {
             sea_level: get_dict_key(value, "GlobalSeaLevel")?,
         })
@@ -322,7 +322,7 @@ impl TryFromDictionary for SimulatorSettings {
 }
 
 impl<T: TryFromDictionary> TryFromDictionary for BTreeMap<TileCoords, T> {
-    fn try_from_dict(value: &Dictionary) -> Result<Self, TryFromDictError> {
+    fn try_from_dict(value: &VarDictionary) -> Result<Self, TryFromDictError> {
         value
             .iter_shared()
             .map(|(key, value)| {
@@ -332,7 +332,7 @@ impl<T: TryFromDictionary> TryFromDictionary for BTreeMap<TileCoords, T> {
                     .map_err(TryFromDictError::InvalidKey)
                     .and_then(|val| array_to_tuple(&val))?;
 
-                let value: Dictionary = value.try_to().map_err(|err| {
+                let value: VarDictionary = value.try_to().map_err(|err| {
                     TryFromDictError::InvalidType(format!("{key:?}").into(), err.into())
                 })?;
 
@@ -343,7 +343,7 @@ impl<T: TryFromDictionary> TryFromDictionary for BTreeMap<TileCoords, T> {
 }
 
 fn get_dict_key<T: FromGodot>(
-    value: &Dictionary,
+    value: &VarDictionary,
     key: &'static str,
 ) -> Result<T, TryFromDictError> {
     value
@@ -354,7 +354,7 @@ fn get_dict_key<T: FromGodot>(
 }
 
 fn get_dict_key_optional<T: FromGodot>(
-    value: &Dictionary,
+    value: &VarDictionary,
     key: &'static str,
 ) -> Result<Option<T>, TryFromDictError> {
     let variant = value.get_or_nil(key);
@@ -369,7 +369,7 @@ fn get_dict_key_optional<T: FromGodot>(
         .map(Some)
 }
 
-fn array_to_tuple(value: &VariantArray) -> Result<TileCoords, TryFromDictError> {
+fn array_to_tuple(value: &VarArray) -> Result<TileCoords, TryFromDictError> {
     Ok((
         value
             .get(0)


### PR DESCRIPTION
Gdext deprecated the Dictionary type in favor of the `VarDictionary` type. In `0.5.0` we will re-introduce the `Dictionary` type with a generic item type.